### PR TITLE
Fix resolving function name to index

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -33,7 +33,7 @@ impl ProgramBuilder {
 
         // Resolve function references with function index
         for function in &mut self.program.functions {
-            for instruction in &mut function.instructions.clone() {
+            for instruction in &mut function.instructions {
                 if let Instruction::FunctionCall(CallTarget::Name(name)) = instruction {
                     if let Some(SymbolEntry::UserDefinedFunction { index }) = self.program.symbol_table.get(name) {
                         *instruction = Instruction::FunctionCall(CallTarget::Index(*index));


### PR DESCRIPTION
Remove a unnecessary clone which result in resolving function name to function index doesn't work.